### PR TITLE
`i2c_simple_write_data_generic()` passes data to `memcpy()` unchecked

### DIFF
--- a/application_processor/src/simple_i2c_controller.c
+++ b/application_processor/src/simple_i2c_controller.c
@@ -209,6 +209,13 @@ int i2c_simple_read_data_generic(i2c_addr_t addr, ECTF_I2C_REGS reg, uint8_t len
 int i2c_simple_write_data_generic(i2c_addr_t addr, ECTF_I2C_REGS reg, uint8_t len, uint8_t* buf) {
     uint8_t packet[257];
     packet[0] = reg;
+
+    if (len > 255 || sizeof(buf) > 255) {
+        // Buffer overflow
+        // TODO: find a way to throw a more human-readable error message
+        return -1;
+    }
+    
     memcpy(&packet[1], buf, len);
     
     mxc_i2c_req_t request;


### PR DESCRIPTION
Taking argument input and feeding it into `memcpy()` without checking to determine how long that data is amounts to a classic buffer overflow vulnerability. This could at the very least cause a crash if used improperly; in the worst case, code can be arbitrarily injected into memory this way. Submitting this PR to begin process of fixing.